### PR TITLE
ISLANDORA-1537: PHP 5.6 Warning in array_traverse_path()

### DIFF
--- a/Array.inc
+++ b/Array.inc
@@ -54,7 +54,8 @@ function &array_traverse_path(array &$array, array $indices) {
   $point = &$array;
   foreach ($indices as $index) {
     if (empty($point[$index])) {
-      return FALSE;
+      $result = FALSE;
+      return $result;
     }
     $point = &$point[$index];
   }


### PR DESCRIPTION
Notice when using PHP 5.6: Only variable references should be returned by reference in array_traverse_path(). This patch returns a variable with the value of FALSE, rather than returning FALSE itself.